### PR TITLE
Add support for selectAccount and "Update Mode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ Check the [Link Docs](https://github.com/plaid/link#custom-integration) for all 
 ```
 
 Once a user has successfully onboarded via Plaid Link, the provided action will be called with the `public_token` passed as the sole argument. From there, you should follow the [instructions](https://github.com/plaid/link#step-3-write-server-side-handler) for exchanging the `public_token` for an `access_token`.
+
+Once you have the `public_token`, you can use it to initialize plaid-link component in "update mode". Update mode allows the user to update Plaid when they change their online-banking credentials or MFA.
+
+```hbs
+{{plaid-link 
+  action='processPlaidToken' 
+  token=$public_token}}
+
+{{!-- Or --}}
+
+{{#plaid-link 
+  action='processPlaidToken' 
+  token=$public_token}}Verify Bank Account{{/plaid-link}}
+```

--- a/addon/components/plaid-link.js
+++ b/addon/components/plaid-link.js
@@ -16,6 +16,7 @@ export default Ember.Component.extend({
   key: null,
   env: null,
   webhook: null,
+  selectAccount: null,
 
   _link: null,
 
@@ -31,7 +32,7 @@ export default Ember.Component.extend({
     this._link = Plaid.create(options);
   }),
 
-  _onSuccess: function(token) {
-    this.sendAction('action', token);
+  _onSuccess: function(token, meta) {
+    this.sendAction('action', token, meta);
   }
 });

--- a/addon/components/plaid-link.js
+++ b/addon/components/plaid-link.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const OPTIONS = ['clientName', 'product', 'key', 'env', 'webhook', 'longtail', 'selectAccount'];
+const OPTIONS = ['clientName', 'product', 'key', 'env', 'webhook', 'longtail', 'selectAccount', 'token'];
 const DEFAULT_LABEL = 'Link Bank Account';
 
 export default Ember.Component.extend({
@@ -17,6 +17,7 @@ export default Ember.Component.extend({
   env: null,
   webhook: null,
   selectAccount: null,
+  token: null,
 
   _link: null,
 

--- a/app/components/plaid-link.js
+++ b/app/components/plaid-link.js
@@ -7,5 +7,6 @@ export default PlaidLink.extend({
   clientName: plaidConfig.clientName,
   product: plaidConfig.product,
   key: plaidConfig.key,
-  env: plaidConfig.env
+  env: plaidConfig.env,
+  selectAccount: plaidConfig.selectAccount
 });


### PR DESCRIPTION
Add support for:
1. Accepting meta parameter in success callback and configuring selectAccount for Plaid client.
2. Initializing component in update mode for users who change their online banking credentials.

Issue: #5 
