### PR TITLE
add apiVersion to options

### DIFF
--- a/addon/components/plaid-link.js
+++ b/addon/components/plaid-link.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const OPTIONS = ['clientName', 'product', 'key', 'env', 'webhook', 'longtail', 'selectAccount', 'token'];
+const OPTIONS = ['clientName', 'product', 'key', 'env', 'webhook', 'apiVersion', 'longtail', 'selectAccount', 'token'];
 const DEFAULT_LABEL = 'Link Bank Account';
 
 export default Ember.Component.extend({
@@ -16,6 +16,7 @@ export default Ember.Component.extend({
   key: null,
   env: null,
   webhook: null,
+  apiVersion: null,
   selectAccount: null,
   token: null,
 


### PR DESCRIPTION
Adds `apiVersion` to the set of parameter options in order to take advantage of updated API endpoints, as outlined in the [Plaid Link transition guide](https://plaid.com/docs/link/transition-guide/).